### PR TITLE
Testing CI

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,26 @@
+name: "Git Context Switcher CodeQL Config"
+
+# Set of queries to run
+queries:
+  # Run the security-extended suite for additional security checks
+  - uses: security-extended
+
+# JavaScript specific settings
+paths-ignore:
+  - "**/node_modules/"
+  - "**/__tests__/"
+  - "**/coverage/"
+  - "jest.config.js"
+
+# Define the query suite precisely if needed
+query-filters:
+  # Exclude specific queries if they cause problems
+  - exclude:
+      id: js/redundant-assignment
+  
+# JavaScript-specific analysis options
+javascript:
+  # Scan dependencies for security vulnerabilities
+  dependencies: true
+  # Scan for XSS vulnerabilities
+  xss-filters: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       # Upload coverage with retry and don't fail the build if upload fails
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
-        continue-on-error: true
+        continue-on-error: false
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,6 +30,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
+          config-file: .github/codeql/codeql-config.yml # Add configuration file reference
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
This pull request includes a change to the CI workflow configuration to ensure that the build fails if coverage report uploads to Codecov fail.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL30-R30): Changed `continue-on-error` from `true` to `false` for the Codecov upload step to ensure build fails if the upload fails.